### PR TITLE
Use `fs.realpathSync` instead as realpath is not on all CLIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "elm-live public/Testpage.elm --output=public/elm.js --dir=public -- --debug --warn",
-    "test": "elm-test --compiler $(which elm-make)"
+    "test": "elm-test --compiler $(node -r fs -p \"fs.realpathSync('node_modules/.bin/elm-make')\")"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "elm-live public/Testpage.elm --output=public/elm.js --dir=public -- --debug --warn",
-    "test": "elm-test --compiler $(realpath node_modules/.bin/elm-make)"
+    "test": "elm-test --compiler $(which elm-make)"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
I'm on Mac OS X and I don't have `realpath`, it's probably safer to assume someone has `which` and use that?

I also tried `readlink` which seems to be on Mac, but that gave error too!