### PR TITLE
Compare translations

### DIFF
--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -1,6 +1,7 @@
 module I18Next exposing
     ( Translations, Delims(..), Replacements, initialTranslations
     , t, tr, tf, trf
+    , keys, diff
     , fetchTranslations, translationsDecoder
     )
 
@@ -18,6 +19,11 @@ needed.
 # Using Translations
 
 @docs t, tr, tf, trf
+
+
+# Comparing Translations
+
+@docs keys, diff
 
 
 # Fetching and Decoding
@@ -248,6 +254,27 @@ trf translationsList delims key replacements =
 
         [] ->
             key
+
+
+{-| Given a set of Translations return a list of the translation keys which are
+defined by the Translations. Useful for comparing those against a list of keys
+actually used in the application.
+-}
+keys : Translations -> List String
+keys translations =
+    case translations of
+        Translations d ->
+            Dict.keys d
+
+
+{-| Returns the keys that are defined in the first translation but not the second
+this is useful for determining which keys need to be translated.
+-}
+diff : Translations -> Translations -> List String
+diff left right =
+    case ( left, right ) of
+        ( Translations leftD, Translations rightD ) ->
+            Dict.diff leftD rightD |> Dict.keys
 
 
 translationRequest : String -> Request Translations

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -14,6 +14,7 @@ import I18Next
         , trf
         )
 import Json.Decode as Decode
+import Set exposing (Set)
 import Test exposing (..)
 
 
@@ -33,6 +34,18 @@ translationJsonEn =
   }"""
 
 
+expectedKeysEn : Set String
+expectedKeysEn =
+    Set.fromList
+        [ "buttons.save"
+        , "buttons.cancel"
+        , "greetings.hello"
+        , "greetings.goodDay"
+        , "englishOnly"
+        , "englishOnlyPlaceholder"
+        ]
+
+
 translationJsonDe : String
 translationJsonDe =
     """{
@@ -45,6 +58,21 @@ translationJsonDe =
       "goodDay": "Guten Tag {{firstName}} {{lastName}}"
     }
   }"""
+
+
+expectedKeysDe : Set String
+expectedKeysDe =
+    Set.fromList
+        [ "buttons.save"
+        , "buttons.cancel"
+        , "greetings.hello"
+        , "greetings.goodDay"
+        ]
+
+
+expectedMissingKeysDe : Set String
+expectedMissingKeysDe =
+    Set.diff expectedKeysEn expectedKeysDe
 
 
 invalidTranslationJson : String
@@ -93,6 +121,7 @@ all =
         , translateWithPlaceholders
         , translateWithFallback
         , translateWithPlaceholdersAndFallback
+        , compareTranslations
         ]
 
 
@@ -190,4 +219,36 @@ translateWithPlaceholdersAndFallback =
             \() ->
                 trf langList Curly "englishOnlyPlaceholder" replacements
                     |> Expect.equal "Only english with Peter Griffin"
+        ]
+
+
+keysOfTranslation : Test
+keysOfTranslation =
+    describe "The keys function"
+        [ test "Checks the list of keys defined in the English translations" <|
+            \() ->
+                I18Next.keys translationsEn
+                    |> Set.fromList
+                    |> Expect.equalSets expectedKeysEn
+        , test "Checks the list of keys defined in the German translations" <|
+            \() ->
+                I18Next.keys translationsDe
+                    |> Set.fromList
+                    |> Expect.equalSets expectedKeysEn
+        ]
+
+
+compareTranslations : Test
+compareTranslations =
+    describe "The diff function"
+        [ test "Checks that if we diff the English and German translations we get the set of englishOnly keys." <|
+            \() ->
+                I18Next.diff translationsEn translationsDe
+                    |> Set.fromList
+                    |> Expect.equalSets expectedMissingKeysDe
+        , test "Checks that if we diff the German and English translations we get the empty set of keys." <|
+            \() ->
+                I18Next.diff translationsDe translationsEn
+                    |> Set.fromList
+                    |> Expect.equalSets Set.empty
         ]


### PR DESCRIPTION
Adds a couple of functions to help get at the keys defined by a translation, useful for deciding what is missing from a translation as compared with another one. This addresses issue #12 