### PR TITLE
Add in the 'toDict' function to retrieve a dictionary from a Translat…

### DIFF
--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -2,6 +2,7 @@ module I18Next exposing
     ( Translations, Delims(..), Replacements, initialTranslations
     , t, tr, tf, trf
     , translationsDecoder
+    , toDict
     )
 
 {-| This library provides a solution to load and display translations in your
@@ -67,6 +68,15 @@ your translations are fetched.
 initialTranslations : Translations
 initialTranslations =
     Translations Dict.empty
+
+
+{-| Use this to obtain a dictionary mapping the translation keys to their translations.
+From this it is simple to, for example, compare two translations for keys defined in one
+but not the other.
+-}
+toDict : Translations -> Dict String String
+toDict (Translations dict) =
+    dict
 
 
 {-| Decode a JSON translations file. The JSON can be arbitrarly nested, but the


### PR DESCRIPTION
…ions, this means the user has the ability to do what they want to translations such as obtain all the defined keys, or compare the keys defined by two translations, without having to expose the underlying type of a translation.

This is an alternative to the pull-request number 15 and somewhat answers issue #12 