### PR TITLE
Support array values

### DIFF
--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -42,7 +42,6 @@ translations.
 
 -}
 
-import Array exposing (Array)
 import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder)
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -27,6 +27,7 @@ translationJsonEn =
       "save": "Save",
       "cancel": "Cancel"
     },
+    "numbers": ["Zero", "One"],
     "greetings": {
       "hello": "Hello",
       "goodDay": "Good Day {{firstName}} {{lastName}}"
@@ -43,6 +44,7 @@ translationJsonDe =
       "save": "Speichern",
       "cancel": "Abbrechen"
     },
+    "numbers": ["Null", "Eins"],
     "greetings": {
       "hello": "Hallo",
       "goodDay": "Guten Tag {{firstName}} {{lastName}}"
@@ -132,6 +134,10 @@ translate =
             \() ->
                 t translationsEn "some.non-existing.key"
                     |> Expect.equal "some.non-existing.key"
+        , test "returns the translation for keys representing array indexes" <|
+            \() ->
+                t translationsEn "numbers.1"
+                    |> Expect.equal "One"
         ]
 
 
@@ -205,6 +211,8 @@ inspecting =
             , "buttons.cancel"
             , "greetings.hello"
             , "greetings.goodDay"
+            , "numbers.0"
+            , "numbers.1"
             ]
     in
     describe "inspecting"


### PR DESCRIPTION
i18n-rails includes some standard translations where the value is an
array. Example:

```
"day_names": [
  "Sonntag",
  "Montag",
  "Dienstag",
  "Mittwoch",
  "Donnerstag",
  "Freitag",
  "Samstag"
]
```

It would be nice to access these translations as  e.g. "daynames.1"