### PR TITLE
Expose Translations constructor

### DIFF
--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -1,5 +1,5 @@
 module I18Next exposing
-    ( Translations, Delims(..), Replacements, initialTranslations
+    ( Translations(..), Delims(..), Replacements, initialTranslations
     , translationsDecoder
     , t, tr, tf, trf
     , keys, hasKey


### PR DESCRIPTION
To be able to create your own translations (e.g. hardcoded) inside Elm, it is necessary
to expose the `Translations` constructor, to make this possible.

My specific use case is to make it easy to switch between dynamic translations, fetched via HTTP, and hardcoded translations, since the feasibility of each can vary with project size.

This makes something like the following possible:

```elm
langEn : Translations
langEn =
    let
        text =
            [ ( "sharedTextToReverse", "Text To Reverse" )
            , ( "sharedReverseText", "Reverse Text" )
            , ( "titleItem", "Item!" )
            , ( "titleNotFound", "Not Found!" )
            ]
    in
    Translations <|
        Dict.fromList
            text
```
