### PR TITLE
Implement custom translations constructors

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "ChristophP/elm-i18next",
     "summary": "A module to load, decode and use translations in your app",
     "license": "BSD-3-Clause",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "exposed-modules": [
         "I18Next"
     ],

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -133,7 +133,8 @@ functions separated with dots.
 -}
 translationsDecoder : Decoder Translations
 translationsDecoder =
-    Decode.map mapTreeToDict treeDecoder
+    Decode.dict treeDecoder
+        |> Decode.map (foldTree >> Translations)
 
 
 treeDecoder : Decoder Tree
@@ -171,16 +172,6 @@ foldTreeHelp initialValue namespace dict =
         )
         initialValue
         dict
-
-
-mapTreeToDict : Tree -> Translations
-mapTreeToDict tree =
-    case tree of
-        Branch dict ->
-            Translations (foldTree dict)
-
-        _ ->
-            initialTranslations
 
 
 {-| Translate a value at a given string.

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -144,8 +144,12 @@ treeDecoder =
         ]
 
 
-foldTree : Dict String String -> Dict String Tree -> String -> Dict String String
-foldTree initialValue dict namespace =
+foldTree : Dict String Tree -> Dict String String
+foldTree dict =
+  foldTreeHelp Dict.empty "" dict
+
+foldTreeHelp : Dict String String  -> String -> Dict String Tree -> Dict String String
+foldTreeHelp initialValue namespace dict =
     Dict.foldl
         (\key val acc ->
             let
@@ -161,7 +165,7 @@ foldTree initialValue dict namespace =
                     Dict.insert (newNamespace key) str acc
 
                 Branch children ->
-                    foldTree acc children (newNamespace key)
+                    foldTreeHelp acc (newNamespace key) children
         )
         initialValue
         dict
@@ -171,8 +175,8 @@ mapTreeToDict : Tree -> Translations
 mapTreeToDict tree =
     case tree of
         Branch dict ->
-            foldTree Dict.empty dict ""
-                |> Translations
+           Translations (foldTree dict)
+
 
         _ ->
             initialTranslations

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -3,7 +3,7 @@ module I18Next exposing
     , translationsDecoder
     , t, tr, tf, trf
     , keys, hasKey
-    , Tree, string, object, fromTree
+    , Tree, fromTree, string, object
     )
 
 {-| This library provides a solution to load and display translations in your
@@ -48,7 +48,7 @@ Most of the time you'll load your translations as JSON form a server, but there
 may be times, when you want to build translations in your code. The following
 functions let you build a `Translations` value programmatically.
 
-@docs Tree, string, object, fromTree
+@docs Tree, fromTree, string, object
 
 -}
 

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -134,7 +134,7 @@ functions separated with dots.
 translationsDecoder : Decoder Translations
 translationsDecoder =
     Decode.dict treeDecoder
-        |> Decode.map (foldTree >> Translations)
+        |> Decode.map (flattenTranslations >> Translations)
 
 
 treeDecoder : Decoder Tree
@@ -146,13 +146,13 @@ treeDecoder =
         ]
 
 
-foldTree : Dict String Tree -> Dict String String
-foldTree dict =
-    foldTreeHelp Dict.empty "" dict
+flattenTranslations : Dict String Tree -> Dict String String
+flattenTranslations dict =
+    foldTree Dict.empty "" dict
 
 
-foldTreeHelp : Dict String String -> String -> Dict String Tree -> Dict String String
-foldTreeHelp initialValue namespace dict =
+foldTree : Dict String String -> String -> Dict String Tree -> Dict String String
+foldTree initialValue namespace dict =
     Dict.foldl
         (\key val acc ->
             let
@@ -168,7 +168,7 @@ foldTreeHelp initialValue namespace dict =
                     Dict.insert (newNamespace key) str acc
 
                 Branch children ->
-                    foldTreeHelp acc (newNamespace key) children
+                    foldTree acc (newNamespace key) children
         )
         initialValue
         dict
@@ -295,4 +295,4 @@ object =
 -}
 fromTree : List ( String, Tree ) -> Translations
 fromTree list =
-    Translations (foldTree (Dict.fromList list))
+    Translations (flattenTranslations (Dict.fromList list))

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -3,8 +3,7 @@ module I18Next exposing
     , translationsDecoder
     , t, tr, tf, trf
     , keys, hasKey
-    , Tree
-    , string, object, fromTree
+    , Tree, fromTree, object, string
     )
 
 {-| This library provides a solution to load and display translations in your
@@ -148,9 +147,10 @@ treeDecoder =
 
 foldTree : Dict String Tree -> Dict String String
 foldTree dict =
-  foldTreeHelp Dict.empty "" dict
+    foldTreeHelp Dict.empty "" dict
 
-foldTreeHelp : Dict String String  -> String -> Dict String Tree -> Dict String String
+
+foldTreeHelp : Dict String String -> String -> Dict String Tree -> Dict String String
 foldTreeHelp initialValue namespace dict =
     Dict.foldl
         (\key val acc ->
@@ -177,8 +177,7 @@ mapTreeToDict : Tree -> Translations
 mapTreeToDict tree =
     case tree of
         Branch dict ->
-           Translations (foldTree dict)
-
+            Translations (foldTree dict)
 
         _ ->
             initialTranslations
@@ -287,14 +286,22 @@ trf translationsList delims key replacements =
             key
 
 
-{-| TODO -}
+{-| TODO
+-}
 string : String -> Tree
-string = Leaf
+string =
+    Leaf
 
-{-| TODO -}
-object : List (String, Tree) -> Tree
-object = Dict.fromList >> Branch
 
-{-| TODO -}
-fromTree : List (String, Tree) -> Translations
-fromTree list = Translations (foldTree (Dict.fromList list))
+{-| TODO
+-}
+object : List ( String, Tree ) -> Tree
+object =
+    Dict.fromList >> Branch
+
+
+{-| TODO
+-}
+fromTree : List ( String, Tree ) -> Translations
+fromTree list =
+    Translations (foldTree (Dict.fromList list))

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -3,6 +3,8 @@ module I18Next exposing
     , translationsDecoder
     , t, tr, tf, trf
     , keys, hasKey
+    , Tree
+    , string, object, fromTree
     )
 
 {-| This library provides a solution to load and display translations in your
@@ -197,7 +199,7 @@ t (Translations translations) key =
 
 
 replacePlaceholders : Replacements -> Delims -> String -> String
-replacePlaceholders replacements delims string =
+replacePlaceholders replacements delims str =
     let
         ( start, end ) =
             delimsToTuple delims
@@ -206,7 +208,7 @@ replacePlaceholders replacements delims string =
         (\( key, value ) acc ->
             String.replace (start ++ key ++ end) value acc
         )
-        string
+        str
         replacements
 
 
@@ -283,3 +285,16 @@ trf translationsList delims key replacements =
 
         [] ->
             key
+
+
+{-| TODO -}
+string : String -> Tree
+string = Leaf
+
+{-| TODO -}
+object : List (String, Tree) -> Tree
+object = Dict.fromList >> Branch
+
+{-| TODO -}
+fromTree : List (String, Tree) -> Translations
+fromTree list = Translations (foldTree (Dict.fromList list))

--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -3,7 +3,7 @@ module I18Next exposing
     , translationsDecoder
     , t, tr, tf, trf
     , keys, hasKey
-    , Tree, fromTree, object, string
+    , Tree, string, object, fromTree
     )
 
 {-| This library provides a solution to load and display translations in your
@@ -41,12 +41,25 @@ translations.
 
 @docs keys, hasKey
 
+
+## Custom Building Translations
+
+Most of the time you'll load your translations as JSON form a server, but there
+may be times, when you want to build translations in your code. The following
+functions let you build a `Translations` value programmatically.
+
+@docs Tree, string, object, fromTree
+
 -}
 
 import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder)
 
 
+{-| A type representing a hierarchy of nested translations. You'll only ever
+deal with this type directly, if you're using
+[`string`](I18Next#string) and [`object`](I18Next#object).
+-}
 type Tree
     = Branch (Dict String Tree)
     | Leaf String
@@ -105,7 +118,7 @@ hasKey (Translations dict) key =
 
 
 {-| Decode a JSON translations file. The JSON can be arbitrarly nested, but the
-leaf values can only be strings. Use this decoder directly if you are passing
+leaf values can only be strings. Use this decoder directly, if you are passing
 the translations JSON into your elm app via flags or ports.
 After decoding nested values will be available with any of the translate
 functions separated with dots.
@@ -283,21 +296,40 @@ trf translationsList delims key replacements =
             key
 
 
-{-| TODO
+{-| Represents the leaf of a translations tree. It holds the actual translation
+string.
 -}
 string : String -> Tree
 string =
     Leaf
 
 
-{-| TODO
+{-| Let's you arange your translations in a hierarchy of objects.
 -}
 object : List ( String, Tree ) -> Tree
 object =
     Dict.fromList >> Branch
 
 
-{-| TODO
+{-| Create a [`Translations`](I18Next#Translations) value from a list of pairs.
+
+    import I18Next exposing (string, object, fromTree, t)
+
+    translations =
+        fromTree
+          [ ("custom"
+            , object
+                [ ( "morning", string "Morning" )
+                , ( "evening", string "Evening" )
+                , ( "afternoon", string "Afternoon" )
+                ]
+            )
+          , ("hello", string "hello")
+          ]
+
+    -- use it like this
+    t translations "custom.morning" -- "Morning"
+
 -}
 fromTree : List ( String, Tree ) -> Translations
 fromTree =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -220,11 +220,24 @@ inspecting =
 
 customTranslations : Test
 customTranslations =
-  describe "custom translations" [
-    fuzz Fuzz.string "can build a working translation with a string" <| \str ->
-      let translations = I18Next.fromTree [("test", I18Next.string str)]
-      in t translations "test" |> Expect.equal str
-    , fuzz Fuzz.string "can build a working translation with an object" <| \str ->
-      let translations = I18Next.fromTree [("obj", I18Next.object [("test", I18Next.string str)])]
-      in t translations "obj.test" |> Expect.equal str
-  ]
+    describe "custom translations"
+        [ fuzz Fuzz.string "can build a working translation with a string" <|
+            \str ->
+                let
+                    translations =
+                        I18Next.fromTree [ ( "test", I18Next.string str ) ]
+                in
+                t translations "test" |> Expect.equal str
+        , fuzz Fuzz.string "can build a working translation with an object" <|
+            \str ->
+                let
+                    translations =
+                        I18Next.fromTree
+                            [ ( "obj"
+                              , I18Next.object
+                                    [ ( "test", I18Next.string str ) ]
+                              )
+                            ]
+                in
+                t translations "obj.test" |> Expect.equal str
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -229,14 +229,14 @@ inspecting =
 customTranslations : Test
 customTranslations =
     describe "custom translations"
-        [ fuzz Fuzz.string "can build a working translation with a string" <|
+        [ fuzz Fuzz.string "can build working translations with a string" <|
             \str ->
                 let
                     translations =
                         I18Next.fromTree [ ( "test", I18Next.string str ) ]
                 in
                 t translations "test" |> Expect.equal str
-        , fuzz Fuzz.string "can build a working translation with an object" <|
+        , fuzz Fuzz.string "can build working translations with an object" <|
             \str ->
                 let
                     translations =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -108,6 +108,14 @@ decode =
 
                     Err err ->
                         Expect.pass
+        , test "fails when the JSON is a string and not an object" <|
+            \() ->
+                case Decode.decodeString translationsDecoder "\"String\"" of
+                    Ok _ ->
+                        Expect.fail "Decoding passed but should have failed."
+
+                    Err err ->
+                        Expect.pass
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,6 +1,7 @@
-module Tests exposing (all)
+module Tests exposing (..)
 
 import Expect
+import Fuzz
 import I18Next
     exposing
         ( Delims(..)
@@ -86,18 +87,6 @@ invalidReplacements =
     [ ( "nonExstingPlaceholder", "Peter" )
     , ( "nonExstingPlaceholder", "Griffin" )
     ]
-
-
-all : Test
-all =
-    describe "The I18Next Module"
-        [ decode
-        , translate
-        , translateWithPlaceholders
-        , translateWithFallback
-        , translateWithPlaceholdersAndFallback
-        , inspecting
-        ]
 
 
 decode : Test
@@ -227,3 +216,15 @@ inspecting =
                         |> Expect.false "key should not be contained but is"
             ]
         ]
+
+
+customTranslations : Test
+customTranslations =
+  describe "custom translations" [
+    fuzz Fuzz.string "can build a working translation with a string" <| \str ->
+      let translations = I18Next.fromTree [("test", I18Next.string str)]
+      in t translations "test" |> Expect.equal str
+    , fuzz Fuzz.string "can build a working translation with an object" <| \str ->
+      let translations = I18Next.fromTree [("obj", I18Next.object [("test", I18Next.string str)])]
+      in t translations "obj.test" |> Expect.equal str
+  ]


### PR DESCRIPTION
closes #21 
- Adds functionality for custom translations without building them from JSON
- some internal refactoring
- make the decoder fail when it encounters just a string not an object of translations(should not break anything, because the `t` function would've failed anyway before)
