### PR TITLE
non-string placeholders

### DIFF
--- a/src/I18Next.elm
+++ b/src/I18Next.elm
@@ -257,6 +257,7 @@ customReplace lift getTranslations delims translationKey replacements =
                     delimsToTuple delims
 
                 -- finds occurences for `Text "pre {{key}} suf {{other}}"`  and replaces them with `[Text "pre ", Placeholder "key", Text " suf {{other}}"]`
+                parseSinglePlaceholderKey : String -> Translation -> List Translation
                 parseSinglePlaceholderKey key translationElement =
                     case translationElement of
                         Text rawText ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -8,6 +8,7 @@ import I18Next
         , Replacements
         , Translations
         , customTr
+        , customTrf
         , hasKey
         , initialTranslations
         , keys
@@ -171,6 +172,32 @@ translateWithCustomizedReturnType =
             \() ->
                 customTr Text translationsEn Curly "some.non-existing.key" []
                     |> Expect.equal [ Text "some.non-existing.key" ]
+        ]
+
+
+translateWithPlaceholdersAndFallbackAndCustomizedReturnType : Test
+translateWithPlaceholdersAndFallbackAndCustomizedReturnType =
+    describe "the customTrf function"
+        [ test "uses the german when the key exists" <|
+            \() ->
+                customTrf Text langList Curly "greetings.hello" []
+                    |> Expect.equal [ Text "Hallo" ]
+        , test "uses english as a fallback" <|
+            \() ->
+                customTrf Text langList Curly "englishOnly" []
+                    |> Expect.equal [ Text "This key only exists in english" ]
+        , test "uses the key if none is found" <|
+            \() ->
+                customTrf Text langList Curly "some.non-existing.key" []
+                    |> Expect.equal [ Text "some.non-existing.key" ]
+        , test "translates and replaces in german when key is found" <|
+            \() ->
+                customTrf Text langList Curly "greetings.goodDay" [ ( "firstName", Link "Peter" ), ( "lastName", Link "Griffin" ) ]
+                    |> Expect.equal [ Text "Guten Tag ", Link "Peter", Text " ", Link "Griffin", Text "" ]
+        , test "translates and replaces in fallback when key is not found" <|
+            \() ->
+                customTrf Text langList Curly "englishOnlyPlaceholder" [ ( "firstName", Link "Peter" ), ( "lastName", Link "Griffin" ) ]
+                    |> Expect.equal [ Text "Only english with ", Link "Peter", Text " ", Link "Griffin", Text "" ]
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -7,6 +7,7 @@ import I18Next
         ( Delims(..)
         , Replacements
         , Translations
+        , customTr
         , hasKey
         , initialTranslations
         , keys
@@ -150,6 +151,29 @@ translateWithPlaceholders =
         ]
 
 
+type PseudoHTML
+    = Text String
+    | Link String
+
+
+translateWithCustomizedReturnType : Test
+translateWithCustomizedReturnType =
+    describe "the customTr function"
+        [ test "translates and replaces placeholders" <|
+            \_ ->
+                customTr Text translationsEn Curly "greetings.goodDay" [ ( "firstName", Link "Test" ), ( "lastName", Link "Max" ) ]
+                    |> Expect.equal [ Text "Good Day ", Link "Test", Text " ", Link "Max", Text "" ]
+        , test "tr does not replace if the match can't be found" <|
+            \_ ->
+                customTr Text translationsEn Curly "greetings.goodDay" [ ( "lastName", Link "Max" ) ]
+                    |> Expect.equal [ Text "Good Day {{firstName}} ", Link "Max", Text "" ]
+        , test "tr returns the key if it doesn not exists" <|
+            \() ->
+                customTr Text translationsEn Curly "some.non-existing.key" []
+                    |> Expect.equal [ Text "some.non-existing.key" ]
+        ]
+
+
 translateWithFallback : Test
 translateWithFallback =
     describe "the tf function"
@@ -165,21 +189,6 @@ translateWithFallback =
             \() ->
                 tf langList "some.non-existing.key"
                     |> Expect.equal "some.non-existing.key"
-        ]
-
-
-type PseudoHTML
-    = Text String
-    | Link String
-
-
-parse : Test
-parse =
-    describe "customTr"
-        [ test "basic" <|
-            \_ ->
-                I18Next.customTr Text translationsEn Curly "greetings.goodDay" [ ( "firstName", Link "Test" ), ( "lastName", Link "Max" ) ]
-                    |> Expect.equal [ Text "Good Day ", Link "Test", Text " ", Link "Max", Text "" ]
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -168,6 +168,21 @@ translateWithFallback =
         ]
 
 
+type PseudoHTML
+    = Text String
+    | Link String
+
+
+parse : Test
+parse =
+    describe "customTr"
+        [ test "basic" <|
+            \_ ->
+                I18Next.customTr Text translationsEn Curly "greetings.goodDay" [ ( "firstName", Link "Test" ), ( "lastName", Link "Max" ) ]
+                    |> Expect.equal [ Text "Good Day ", Link "Test", Text " ", Link "Max", Text "" ]
+        ]
+
+
 translateWithPlaceholdersAndFallback : Test
 translateWithPlaceholdersAndFallback =
     describe "the trf function"


### PR DESCRIPTION
- Basic implementation for #26

Notes:
- customTr "parses" the translation string into: `[Text "Good Day ", Placeholder "firstName", Text " ", Placeholder "lastName"]`
     - Maybe add that to the decoder?
- graceful handling of missing replacements: `customTr ... [("lastName", "Mustermann")]` will return `"Good Day {{firstName}} {{lastName}}"`
    - disadvantage: Parsing is dependent on replacements
    - advantage: mimics behaviour of `tr`