### PR TITLE
add actual copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright (c) 2017 Christoph Pölt
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
I'm adding copyright notices from dependent libraries to my app to follow the licenses, and I noticed that `elm-i18next`'s `LICENSE` file leaves the placeholders as-is. And now, my app retains the placeholders as literally required by the license, but that doesn't feel quite right, so here is an attempt at fixing it fundamentally.

The year is taken from the date of the initial commit of the repository.